### PR TITLE
Update README.es.md

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -119,7 +119,7 @@ Con el script ejecutándose en Windows, ya puedes enviar comandos desde Kali a t
 
 - **Cambiar de directorio:**:
     ```bash
-    tasklist
+    cd
     ```
 - **Crear un archivo o directorio:**:
     ```bash


### PR DESCRIPTION
había una errata en el comando mostrado para navegar por el sistema de directorios, en vez de poner el comando "cd" indicaba que se debería de utilizar el comando "tasklist".